### PR TITLE
Infinite Loop During XPATH Evaluation

### DIFF
--- a/ximple-dev/com/ximpleware/LocationPathExpr.java
+++ b/ximple-dev/com/ximpleware/LocationPathExpr.java
@@ -2388,6 +2388,9 @@ public class LocationPathExpr extends Expr{
 		  		 state =  BACKWARD;
 		  	vn.push2();
 		  	while (vn.toElement(VTDNav.PS)){
+		  	    	if(vn.atTerminal &&  !(currentStep.nt_eval || currentStep.nt.eval(vn) )){
+		  	        	break;
+	            		}
 		  		if ((currentStep.nt_eval || currentStep.nt.eval(vn)) 
 		  				&& ((!currentStep.hasPredicate) || currentStep.evalPredicates(vn))){
 		  			if (currentStep.nextS!=null){
@@ -2421,6 +2424,9 @@ public class LocationPathExpr extends Expr{
 		  
 		  case  BACKWARD:
 		  	while (vn.toElement(VTDNav.PS)){
+		  		if(vn.atTerminal &&  !(currentStep.nt_eval || currentStep.nt.eval(vn) )){
+		  	       		break;
+		  	    	}
 		  		if ((currentStep.nt_eval || currentStep.nt.eval(vn)) 
 		  				&& ((!currentStep.hasPredicate) || currentStep.evalPredicates(vn))){
 		  			if (currentStep.nextS!=null){
@@ -2777,8 +2783,11 @@ public class LocationPathExpr extends Expr{
 				}
 			}
 		}
-		
+		int ctr = 0;
 		while (true) {
+			if(ctr++ > 100000){
+		        	throw new XPathEvalException("Cyclic XPATH detected"); 
+		    	}
 			switch (currentStep.axis_type) {
 
 			case AxisType.CHILD0:


### PR DESCRIPTION
### Example 1
**xpath:**
`/descendant::td[@id="address"]/p/text()[count(preceding-sibling::br) < 1]`

**xml**
```
<table>
	<tbody>
		<tr>
			<td id='address'>
				Address Location
				<p>
					Yahoo Inc!
					<br />
					701 1st Ave
					<br />
					Sunnyvale, CA, US 94089
				</p>

			</td>
			<tr>
				<td id='address'>
					Address Location
					<p>
						Yahoo Inc!2
						<br />
						701 1st Ave2
						<br />
						Sunnyvale, CA, US 940892
					</p>

				</td>
			</tr>
		</tr>

	</tbody>
</table>
```

------------------------------------------------------------------------------------------------------------------------
### Example 2
**xpath:**
`/descendant-or-self::node()/child::font [contains (self::node() ,"number")]/ancestor::tr [1]/following-sibling::tr [1]/descendant-or-self::node()/child::b`

**xml:**
```
<table>
	<tbody>
		<tr>
			<td>
				Address Location
				<font>
					tracking number

				</font>

			</td>

		</tr>
		<tr>
			<td>
				<b>12312321312</b>

			</td>
		</tr>
	</tbody>
</table>
```